### PR TITLE
Updated logWriter.js

### DIFF
--- a/lib/logWriter.js
+++ b/lib/logWriter.js
@@ -71,7 +71,7 @@
                     throw err;
                 } else {
                     try {
-                        self.history = JSON.parse(data);
+                        self.history = JSON.parse(JSON.stringify(data));
                     } catch (e) {
                         throw e;
                     }


### PR DESCRIPTION
If there is already an existing Log file from previous session, I used to get JSON parse error  (“Uncaught SyntaxError: Unexpected token o”) .

It was because the file was being read as an Object, but the JSOIN.parse method requires the object in String format .