### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 
 # UPDATE: Download Scribe 3.0 [Alpha 10](https://github.com/bluejamesbond/Scribe.js/tree/dev)
 
-#Overview
+# Overview
 
 Unlike many of the libraries out there, Scribe.js allows logging on multiple files and is divided into folders by date. And it is possibly the easiest logging you can implement.
 
-##WebPanel
+## WebPanel
 ![webPanel](__misc/webPanelDemo.gif)  
 
-##Terminal
+## Terminal
 ![terminal](__misc/terminalDemo.png)  
 
-##Features
+## Features
 
 - Allows you to use the `console` object (which provides easy integration with existing systems)
 - Save messages into JSON log files organized by user, date, and type or your custom rule
@@ -27,19 +27,19 @@ Unlike many of the libraries out there, Scribe.js allows logging on multiple fil
 - Provides a developer API to access your logs
 - Features a rich HTML web panel to access logs from anywhere in the world
 
-#Live Demo
+# Live Demo
 You can access a live demo of the library [here](https://bluejamesbond.github.io/Scribe.js/).
 
-#Wiki
+# Wiki
 
 For examples, tests, and API refer to the [Scribe.js Wiki](https://github.com/bluejamesbond/Scribe.js/wiki).
 
-#Installation
+# Installation
 ```
 npm install scribe-js
 ```
 
-#Contributors
+# Contributors
 
 - [bluejamesbond](https://github.com/bluejamesbond)
 - [guillaumewuip](https://github.com/guillaumewuip)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
